### PR TITLE
bugfix334 Add dark mode to signout loading page

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      # Add Node.js setup step
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+
       - name: NPM install
         run: npm install
 
       - name: SvelteKit Build 
-        run: npm run build 
+        run: npm run build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,3 +28,4 @@ jobs:
 
       - name: SvelteKit Build 
         run: npm run build
+

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,6 +17,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      # Add Node.js setup step
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+
       - name: NPM install
         run: npm install
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -17,11 +17,17 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      # Add Node.js setup step
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+
       - name: NPM install
         run: npm install
 
       - name: Linting
         run: npm run lint
- 
+
       - name: Typechecking
         run: npm run check

--- a/src/routes/(admin)/account/sign_out/+page.svelte
+++ b/src/routes/(admin)/account/sign_out/+page.svelte
@@ -188,11 +188,11 @@
   })
 </script>
 
-<div class="flex min-h-screen items-center justify-center bg-gray-50">
+<div class="flex min-h-screen items-center justify-center">
   <div class="w-full max-w-md p-8 text-center">
-    <div class="rounded-lg bg-white p-8 shadow-lg" transition:fade>
-      <h1 class="mb-2 text-2xl font-bold text-gray-900">{message}</h1>
-      <p class="mb-6 text-sm text-gray-600">{subMessage}</p>
+    <div class="rounded-lg p-8 shadow-lg" transition:fade>
+      <h1 class="mb-2 text-2xl font-bold">{message}</h1>
+      <p class="mb-6 text-sm">{subMessage}</p>
 
       {#if isSigningOut}
         <div class="mb-4">


### PR DESCRIPTION
Current change:
![image](https://github.com/user-attachments/assets/cdd50b98-e909-4d5f-a2aa-47b35931ab4f)



This is a dark background with a white component, but I'm not sure if you like it. For this change, you just need to modify line 191.
![image](https://github.com/user-attachments/assets/12c1b797-f2c9-444c-aca2-7f854c051a05)
